### PR TITLE
Remove unnecessary Windows Server checks

### DIFF
--- a/Crunchyroll Downloader/Anime_Add.vb
+++ b/Crunchyroll Downloader/Anime_Add.vb
@@ -286,10 +286,6 @@ Public Class Anime_Add
             List_DL_Cancel = False
             pictureBox4.Image = My.Resources.main_button_download_default
         End If
-        If InStr(My.Computer.Info.OSFullName, "Server") Then
-            MsgBox("Windows Server is not supported!", MsgBoxStyle.Critical)
-            Me.Close()
-        End If
         pictureBox4.Enabled = True
     End Sub
 

--- a/Crunchyroll Downloader/GeckoFX.vb
+++ b/Crunchyroll Downloader/GeckoFX.vb
@@ -15,11 +15,6 @@ Public Class GeckoFX
     Dim t As Thread
     Dim ScanTrue As Boolean = False
     Private Sub GeckoWebBrowser1_DocumentCompleted(sender As Object, e As EventArgs) Handles WebBrowser1.DocumentCompleted
-        If InStr(My.Computer.Info.OSFullName, "Server") Then
-            MsgBox("Windows Server is not supported!", MsgBoxStyle.Critical)
-            Me.Close()
-        End If
-
         If ScanTrue = False Then
             Button2.Enabled = True
         End If

--- a/Crunchyroll Downloader/Main.vb
+++ b/Crunchyroll Downloader/Main.vb
@@ -144,11 +144,6 @@ Public Class Main
     Public Declare Function waveOutSetVolume Lib "winmm.dll" (ByVal uDeviceID As Integer, ByVal dwVolume As Integer) As Integer
 
     Private Sub Form8_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        If InStr(My.Computer.Info.OSFullName, "Server") Then
-            MsgBox("Windows Server is not supported!", MsgBoxStyle.Critical)
-            Me.Close()
-        End If
-
         waveOutSetVolume(0, 0)
         Try
             Dim FileLocation As DirectoryInfo = New DirectoryInfo(Application.StartupPath)


### PR DESCRIPTION
The checks to prohibit this program from running on Server versions of Windows are unnecessary. Removed these checks as the program runs perfectly fine under Windows Server.

Tested against Windows Server 2016 Standard Version 1607 Build 14393.3542